### PR TITLE
Allow react v17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,8 +144,8 @@
     "webpack": "^4.42.1"
   },
   "peerDependencies": {
-    "react": "^16.8.5",
-    "react-dom": "^16.8.5"
+    "react": "^16.8.5 || ^17.0.0",
+    "react-dom": "^16.8.5 || ^17.0.0"
   },
   "license": "Apache-2.0",
   "jest-junit": {


### PR DESCRIPTION
### Why

This pull request is to allow react 17 as peer dependency. This version of react should ([in theory](https://reactjs.org/blog/2020/10/20/react-v17.html#other-breaking-changes)) not break anything. At work we are currently on react 17, we've had no issue related to it and we are on the latest version of [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd).

Related to: https://github.com/atlassian/react-beautiful-dnd/issues/1993